### PR TITLE
Support Z-Wave Blinds

### DIFF
--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -2133,7 +2133,6 @@ FHEMDevice(platform, s) {
             }
         } else if (s.Internals.TYPE == 'ZWave' ) {
             this.mappings.On = {reading: 'state', valueOff: 'off', cmdOn: 'on', cmdOff: 'off', max: 99};
-
             if(s.Readings.position !== undefined) { 
                 // FIBARO System FGRM222 Roller Shutter Controller 2
                 // If the device is configured to use Fibaro command class instead of ZWave command class,
@@ -2143,7 +2142,7 @@ FHEMDevice(platform, s) {
             } else {
                 this.mappings.CurrentPosition = {reading: 'state'};
                 this.mappings.TargetPosition = {reading: 'state', cmd: 'dim', delay: true};
-            }            
+            }
         } else {
             this.mappings.CurrentPosition = {reading: 'pct'};
             this.mappings.TargetPosition = {reading: 'pct', cmd: 'pct', delay: true};

--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -2131,6 +2131,19 @@ FHEMDevice(platform, s) {
                 this.mappings.TargetPosition.invert = true;
                 this.mappings.TargetPosition.cmd = 'pos';
             }
+        } else if (s.Internals.TYPE == 'ZWave' ) {
+            this.mappings.On = {reading: 'state', valueOff: 'off', cmdOn: 'on', cmdOff: 'off', max: 99};
+
+            if(s.Readings.position !== undefined) { 
+                // FIBARO System FGRM222 Roller Shutter Controller 2
+                // If the device is configured to use Fibaro command class instead of ZWave command class,
+                // then there's a reading "position" present which must be used instead.
+                this.mappings.CurrentPosition = {reading: 'position'};
+                this.mappings.TargetPosition = {reading: 'position', cmd: 'dim', delay: true};
+            } else {
+                this.mappings.CurrentPosition = {reading: 'state'};
+                this.mappings.TargetPosition = {reading: 'state', cmd: 'dim', delay: true};
+            }            
         } else {
             this.mappings.CurrentPosition = {reading: 'pct'};
             this.mappings.TargetPosition = {reading: 'pct', cmd: 'pct', delay: true};


### PR DESCRIPTION
I've noticed that the current implementation does not work with ZWave shutter actors like [Fibaro Roller Shutter 2](https://www.fibaro.com/en/products/roller-shutter-2/) or [Qubino Flush Shutter](http://qubino.com/products/flush-shutter/).

This PR is tested successfully with both actors and should work for any Z-Wave actor for controlling blinds.